### PR TITLE
Normal: service token to use fw-core output instead of local secret (small)

### DIFF
--- a/.github/workflows/terraform_build.yaml
+++ b/.github/workflows/terraform_build.yaml
@@ -19,9 +19,8 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.aws_key_production }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_production }}
         AWS_REGION: ${{ secrets.aws_region_production }}
-        MICROSERVICE_TOKEN: ${{ secrets.microservice_token }}
       run: |
-        ./scripts/infra plan -var "microservice_token_secret_string=${MICROSERVICE_TOKEN}"
+        ./scripts/infra plan
         ./scripts/infra apply
     - name: Deploy staging
       if: success() && github.ref == 'refs/heads/staging'
@@ -30,9 +29,8 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.aws_key_staging }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_staging }}
         AWS_REGION: ${{ secrets.aws_region_staging }}
-        MICROSERVICE_TOKEN: ${{ secrets.microservice_token }}
       run: |
-        ./scripts/infra plan -var "microservice_token_secret_string=${MICROSERVICE_TOKEN}"
+        ./scripts/infra plan
         ./scripts/infra apply
     - name: Deploy dev
       if: success() && github.ref == 'refs/heads/dev'
@@ -41,7 +39,6 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.aws_key_dev }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_dev }}
         AWS_REGION: ${{ secrets.aws_region_dev }}
-        MICROSERVICE_TOKEN: ${{ secrets.microservice_token }}
       run: |
-        ./scripts/infra plan -var "microservice_token_secret_string=${MICROSERVICE_TOKEN}"
+        ./scripts/infra plan
         ./scripts/infra apply

--- a/.github/workflows/terraform_plan.yaml
+++ b/.github/workflows/terraform_plan.yaml
@@ -15,8 +15,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.aws_key_production }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_production }}
         AWS_REGION: ${{ secrets.aws_region_production }}
-        MICROSERVICE_TOKEN: ${{ secrets.microservice_token }}
-      run: ./scripts/infra plan -var "microservice_token_secret_string=${MICROSERVICE_TOKEN}"
+      run: ./scripts/infra plan
     - name: Plan staging
       if: github.base_ref == 'staging'
       env:
@@ -24,8 +23,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.aws_key_staging }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_staging }}
         AWS_REGION: ${{ secrets.aws_region_staging }}
-        MICROSERVICE_TOKEN: ${{ secrets.microservice_token }}
-      run: ./scripts/infra plan -var "microservice_token_secret_string=${MICROSERVICE_TOKEN}"
+      run: ./scripts/infra plan
     - name: Plan dev
       if: github.base_ref == 'dev'
       env:
@@ -33,6 +31,5 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.aws_key_dev }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_dev }}
         AWS_REGION: ${{ secrets.aws_region_dev }}
-        MICROSERVICE_TOKEN: ${{ secrets.microservice_token }}
-      run: ./scripts/infra plan -var "microservice_token_secret_string=${MICROSERVICE_TOKEN}"
+      run: ./scripts/infra plan
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -43,8 +43,7 @@ module "fargate_autoscaling" {
     data.terraform_remote_state.fw_core.outputs.data_bucket_write_policy_arn
   ]
   task_execution_role_policies = [
-    data.terraform_remote_state.core.outputs.document_db_secrets_policy_arn,
-    module.microservice_token_secret.read_policy_arn
+    data.terraform_remote_state.core.outputs.document_db_secrets_policy_arn
   ]
   container_definition = data.template_file.container_definition.rendered
 
@@ -57,8 +56,7 @@ module "fargate_autoscaling" {
   priority = 6
 
   depends_on = [
-    module.app_docker_image,
-    module.microservice_token_secret
+    module.app_docker_image
   ]
 }
 
@@ -90,7 +88,6 @@ data "template_file" "container_definition" {
     api_version = var.api_version
     rw_areas_api_url = var.rw_areas_api_url
     # Secrets
-    microservice_token_secret: module.microservice_token_secret.secret_arn
     # none
   }
 
@@ -116,16 +113,6 @@ module "route53_healthcheck" {
   depends_on = [
     module.fargate_autoscaling
   ]
-}
-
-#
-# Secrets
-#
-module "microservice_token_secret" {
-  source        = "git::https://github.com/wri/gfw-terraform-modules.git//terraform/modules/secrets?ref=v0.5.1"
-  project       = var.project_prefix
-  name          = "${var.project_prefix}-microservice-token"
-  secret_string = var.microservice_token_secret_string
 }
 
 #

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -43,7 +43,8 @@ module "fargate_autoscaling" {
     data.terraform_remote_state.fw_core.outputs.data_bucket_write_policy_arn
   ]
   task_execution_role_policies = [
-    data.terraform_remote_state.core.outputs.document_db_secrets_policy_arn
+    data.terraform_remote_state.core.outputs.document_db_secrets_policy_arn,
+    data.terraform_remote_state.fw_core.outputs.microservice_token_secret_policy_arn
   ]
   container_definition = data.template_file.container_definition.rendered
 
@@ -88,6 +89,7 @@ data "template_file" "container_definition" {
     api_version = var.api_version
     rw_areas_api_url = var.rw_areas_api_url
     # Secrets
+    microservice_token_secret: data.terraform_remote_state.fw_core.outputs.microservice_token_secret_arn
     # none
   }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -96,7 +96,3 @@ variable "healthcheck_path" {
 variable "healthcheck_sns_emails" {
   type = list(string)
 }
-
-variable "microservice_token_secret_string" {
-  type    = string
-}


### PR DESCRIPTION
fw-api was using a local secret to access the service token.

Now it will use the one outputted from fw-core, like the rest the of the services!