### PR TITLE
Fix operation id duplicate for healthcheck v3

### DIFF
--- a/docs/fw_api.yaml
+++ b/docs/fw_api.yaml
@@ -54,7 +54,7 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Healthcheck'
-      operationId: get-fw_api-healthcheck
+      operationId: get-v3-fw_api-healthcheck
       security: []
       tags:
         - v3


### PR DESCRIPTION
Fix OpenAPI docs where the healthcheck operation id was duplicated between v1 and v3. This caused errors in codegen on the frontend development as operation ids cannot be duplicates